### PR TITLE
pip install error, missing README.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE
-include README.rst
+include README.md


### PR DESCRIPTION
should fix install problem for the missing "README.md" from the manifest
