### PR TITLE
Fix opposite sign of timezone

### DIFF
--- a/ghp-import
+++ b/ghp-import
@@ -92,7 +92,7 @@ def get_prev_commit(branch):
 def mk_when(timestamp=None):
     if timestamp is None:
         timestamp = int(time.time())
-    currtz = "%+05d" % (time.timezone / 36) # / 3600 * 100
+    currtz = "%+05d" % (-1 * time.timezone / 36) # / 3600 * 100
     return "%s %s" % (timestamp, currtz)
 
 


### PR DESCRIPTION
time.timezone returns offset of the opposite
sign from what we normally use in UTC offset

For example,
CST is actually UTC +0800
http://www.timeanddate.com/library/abbreviations/timezones/asia/cst.html

``` python
>>> import time
>>> time.tzname
('CST', 'CST')
>>> "%+05d" % (time.timezone / 36)
-0800
```
