### PR TITLE
Get prev commit revision right.

### DIFF
--- a/ghp-import
+++ b/ghp-import
@@ -67,7 +67,7 @@ def get_config(key):
 
 
 def get_prev_commit(branch):
-    cmd = ['git', 'rev-list', '--max-count=1', 'refs/heads/%s' % branch]
+    cmd = ['git', 'rev-list', '--max-count=1', branch, '--']
     p = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
     (rev, ignore) = p.communicate()
     if p.wait() != 0:


### PR DESCRIPTION
Before the fix:

```
$ git rev-list --max-count=1 branch
```

This will always throw an error. The fixed version is:

```
$ git rev-list --max-count=1 refs/heads/branch
```

Related issue: https://github.com/davisp/ghp-import/issues/18
