### PR TITLE
Fix name and email with Python3

### DIFF
--- a/ghp-import
+++ b/ghp-import
@@ -83,8 +83,8 @@ def mk_when(timestamp=None):
 
 
 def start_commit(pipe, branch, message):
-    uname = get_config("user.name")
-    email = get_config("user.email")
+    uname = str(get_config("user.name"))
+    email = str(get_config("user.email"))
     write(pipe, enc('commit refs/heads/%s\n' % branch))
     write(pipe, enc('committer %s <%s> %s\n' % (uname, email, mk_when())))
     write(pipe, enc('data %d\n%s\n' % (len(message), message)))


### PR DESCRIPTION
Used to be:
Author: b'Martin Paljak' <b'martin@martinpaljak.net'>

Now is:
Author: Martin Paljak martin@martinpaljak.net
