### PR TITLE
Support executable files maybe

### DIFF
--- a/ghp-import
+++ b/ghp-import
@@ -115,7 +115,7 @@ def start_commit(pipe, branch, message):
 
 def add_file(pipe, srcpath, tgtpath):
     with open(srcpath, "rb") as handle:
-        if os.fstat(handle.fileno()).st_mode & 0o111:
+        if os.access(srcpath, os.X_OK):
             write(pipe, enc('M 100755 inline %s\n' % tgtpath))
         else:
             write(pipe, enc('M 100644 inline %s\n' % tgtpath))


### PR DESCRIPTION
Here's my use case: I'm deploying a mostly static website that needs one CGI script.  To simplify deployment I thought I would put it together with all the static files and import it into my gh-pages branch, then tell Apache to treat it as CGI with a

```
ScriptAlias /myscript.py /var/www/mywebsite.com/myscript.py
```

Unfortunately ghp-import drops the executable bit which makes Apache refuse to run it as a CGI script.

It would be nice if ghp-import noticed that the file it was importing has the executable bit set and not discard it.

Would you be willing to accept a patch to preserve the executable bits?  If so, is it fine to do that unconditionally, or should I add a command-line option?

Feel free to tell me this request is out of scope for ghp-import, or that it would cause harm with files getting marked executable unnecessarily because people use Windows, or something.
