### PR TITLE
Open the README as UTF8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 import os
 import sys
+from io import open
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-LONG_DESC = open(os.path.join(os.path.dirname(__file__), "README.md")).read()
+LONG_DESC = open(os.path.join(os.path.dirname(__file__), "README.md"), 'r', encoding='utf-8').read()
 
 setup(
     name = "ghp-import",


### PR DESCRIPTION
This is [currently failing](https://travis-ci.org/mkdocs/mkdocs/builds/62375906) on Python 3.4.3 and 3.3.6 (3.4.2 and 3.3.5 work fine). Relevant error below.

    Downloading ghp-import-0.4.1.tar.gz
      Complete output from command python setup.py egg_info:
      Traceback (most recent call last):
        File "<string>", line 20, in <module>
        File "/tmp/pip-build-ex1g85/ghp-import/setup.py", line 9, in <module>
          LONG_DESC = open(os.path.join(os.path.dirname(__file__), "README.md")).read()
        File "/home/travis/build/mkdocs/mkdocs/.tox/py33-unittests/lib/python3.3/encodings/ascii.py", line 26, in decode
          return codecs.ascii_decode(input, self.errors)[0]
      UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1362: ordinal not in range(128)
      
      ----------------------------------------
      Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-ex1g85/ghp-import