### PR TITLE
fixes #41. Popen.communte() returns bytes. Str expected

### DIFF
--- a/ghp-import
+++ b/ghp-import
@@ -72,6 +72,8 @@ def try_rebase(remote, branch):
     cmd = ['git', 'rev-list', '--max-count=1', 'origin/%s' % branch]
     p = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
     (rev, ignore) = p.communicate()
+    if isinstance(rev, bytes):
+        rev = rev.decode()
     if p.wait() != 0:
         return True
     cmd = ['git', 'update-ref', 'refs/heads/%s' % branch, rev.strip()]


### PR DESCRIPTION
See #41 
