### PR TITLE
Remove the deprecated GIT_DIR in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ a different remote using the `-r` flag.
 You can specify a different branch with `-b`. This is useful for user and
 organization page, which are served from the `master` branch.
 
-`ghp-import` also recognizes the `GIT_DIR` environment variable which can be
-useful for Git hooks.
-
 License
 -------
 


### PR DESCRIPTION
Now we use `git rev-parse` to detect a git repo. GIT_DIR is deprecated and we don't use at all, so remove it.

we add GIT_DIR in 8f62fb4c8d5ca31b5c578c35a44650a68b12ce61, and remove it in 691dbe2e505946cf73aeedbb017bb904671099f7, but seems forget to update the reamde.

Let me know If I misunderstood something.