### PR TITLE
Use remote argument rather than 'origin'

### DIFF
--- a/ghp-import
+++ b/ghp-import
@@ -69,7 +69,7 @@ def check_repo(parser):
 
 
 def try_rebase(remote, branch):
-    cmd = ['git', 'rev-list', '--max-count=1', 'origin/%s' % branch]
+    cmd = ['git', 'rev-list', '--max-count=1', '%s/%s' % (remote, branch)]
     p = sp.Popen(cmd, stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
     (rev, ignore) = p.communicate()
     if p.wait() != 0:


### PR DESCRIPTION
The `remote` variable is unused, since the default value for `remote` is `origin`, so I think we should use `remote`. Any ideas?