### PR TITLE
Fix the incorrect timezone offset calculation (issue #45)

### DIFF
--- a/ghp-import
+++ b/ghp-import
@@ -98,7 +98,7 @@ def get_prev_commit(branch):
 def mk_when(timestamp=None):
     if timestamp is None:
         timestamp = int(time.time())
-    currtz = "%+05d" % (-1 * time.timezone / 36) # / 3600 * 100
+    currtz = time.strftime('%z')
     return "%s %s" % (timestamp, currtz)
 
 


### PR DESCRIPTION
The timezone offset is calculated incorrectly for time zones which do not have a whole number hour as the offset. For example IST has +0530. Fix it by using `time.strtime('z')` to calculate the current timezone.
