### PR TITLE
BF: convert revision to str for call

### DIFF
--- a/ghp_import.py
+++ b/ghp_import.py
@@ -74,7 +74,8 @@ def try_rebase(remote, branch):
     (rev, ignore) = p.communicate()
     if p.wait() != 0:
         return True
-    cmd = ['git', 'update-ref', 'refs/heads/%s' % branch, rev.strip()]
+    rev = rev.strip().decode('ascii')
+    cmd = ['git', 'update-ref', 'refs/heads/%s' % branch, rev]
     if sp.call(cmd) != 0:
         return False
     return True


### PR DESCRIPTION
Avoid error converting str / bytes in subprocess.call

Without this change, on Windows and Python 3.5, I get this from `ghp-import
_build/html`:

(py35) C:\repos\la-eeg-uci [master]> ghp-import.exe ._build\html
Traceback (most recent call last):
    File "C:\tmp\py35\Scripts\ghp-import-script.py", line 9, in <module>
        load_entry_point('ghp-import==0.4.2', 'console_scripts', 'ghp-import')()
    File "c:\repos\ghp-import\ghp_import.py", line 194, in main
        if not try_rebase(opts.remote, opts.branch):
    File "c:\repos\ghp-import\ghp_import.py", line 78, in try_rebase
        if sp.call(cmd) != 0:
    File "C:\Python35\lib\subprocess.py", line 560, in call
        with Popen(_popenargs, *_kwargs) as p:
    File "C:\Python35\lib\subprocess.py", line 950, in **init**
        restore_signals, start_new_session)
    File "C:\Python35\lib\subprocess.py", line 1194, in _execute_child
        args = list2cmdline(args)
    File "C:\Python35\lib\subprocess.py", line 754, in list2cmdline
        needquote = (" " in arg) or ("\t" in arg) or not arg
TypeError: a bytes-like object is required, not 'str'
