### PR TITLE
Support using as library.

### DIFF
--- a/ghp_import.py
+++ b/ghp_import.py
@@ -216,9 +216,15 @@ def options():
     ]
 
 
-def main():
+def main(*args, **kwargs):
     parser = op.OptionParser(usage=__usage__, option_list=options())
-    opts, args = parser.parse_args()
+    if not args:
+        opts, args = parser.parse_args()
+    else:
+        opts = parser.get_default_values()
+        for opt, value in kwargs.items():
+            if opt in dir(opts):
+                setattr(opts, opt, value)
 
     if len(args) == 0:
         parser.error("No import directory specified.")


### PR DESCRIPTION
Third party Python scripts can now call ghp-import directly.  The `main`
function now accepts args and kwargs where args is the  commandline
positional arguments and kwargs are key/value pairs of the commandline
options. If args (and optionally kwargs) is passed  to `main`, then
those values are used. If args is blank, then  `sys.argv` is used as
previously. This allows a user to do:

    import ghp_import
    ghp-import.main('path/to/dir', branch='master', followlinks=True)

This uses the least intrusive method possible by making use the
OptionParser's return values. A more complete solution would wrap the
OptionParser specific code in a separate function ad pass those in as
keywords to the primary function. But then the rest of the code would
need to be refactored to not use the `opts` and `parser` objects.

As an aside, this is made possible because of commit ef30cbf, which
now installs the module as a lib rather than a script (which puts in
on the PYTHONPATH and makes it importable).