### PR TITLE
Support use as library

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,32 @@ Some Windows users report needing to pass Git commands through the shell which c
 
 The `-l` option will cause the import to follow symlinks for users that have odd configurations that include symlinking outside of their documentation directory.
 
+Python Usage
+------------
+
+You can also call ghp_import directly from your Python code as a library. The
+library has one public function `ghp_import.ghp_import`, which accepts the
+following arguments:
+
+* `srcdir`: The path to the **built** documentation (required).
+* `remote`: The name of the remote to push to. Default: `origin`.
+* `branch`: Name of the branch to write to. Default: `gh-pages`.
+* `mesg`: The commit message to use on the target branch. Default: `Update documentation`.
+* `push`: Push the branch to {remote}/{branch} after committing. Default: `False`.
+* `force`: Force the push to the repository. Default: `False`.
+* `use_shell`: Default: Use the shell when invoking Git. `False`.
+* `followlinks`: Follow symlinks when adding files. Default: `False`.
+* `cname`: Write a CNAME file with the given CNAME. Default: `None`.
+* `nojekyll`: Include a .nojekyll file in the branch. Default: `False`.
+
+With Python's current working directory (cwd) inside your repository, do the
+following:
+
+```python
+from ghp_import import ghp_import
+ghp_import('docs', push=True, cname='example.com')
+```
+
 License
 -------
 

--- a/ghp_import.py
+++ b/ghp_import.py
@@ -248,8 +248,8 @@ def ghp_import(srcdir, **kwargs):
 
     run_import(git, srcdir, **opts)
 
-    if push:
-        if force:
+    if opts['push']:
+        if opts['force']:
             git.check_call('push', opts['remote'], opts['branch'], '--force')
         else:
             git.check_call('push', opts['remote'], opts['branch'])

--- a/ghp_import.py
+++ b/ghp_import.py
@@ -12,7 +12,13 @@ import sys
 import time
 import unicodedata
 
+__all__ = ['ghp_import']
+
 __usage__ = "%prog [OPTIONS] DIRECTORY"
+
+
+class GhpError(Exception):
+    pass
 
 
 if sys.version_info[0] == 3:
@@ -56,7 +62,7 @@ class Git(object):
         self.stderr = None
         self.stdout = None
 
-    def check_repo(self, parser):
+    def check_repo(self):
         if self.call('rev-parse') != 0:
             error = self.stderr
             if not error:
@@ -64,7 +70,7 @@ class Git(object):
             error = dec(error)
             if error.startswith("fatal: "):
                 error = error[len("fatal: "):]
-            parser.error(error)
+            raise GhpError(error)
 
     def try_rebase(self, remote, branch):
         rc = self.call('rev-list', '--max-count=1', '%s/%s' % (remote, branch))
@@ -161,26 +167,26 @@ def gitpath(fname):
     return "/".join(norm.split(os.path.sep))
 
 
-def run_import(git, srcdir, opts):
+def run_import(git, srcdir, **opts):
     cmd = ['git', 'fast-import', '--date-format=raw', '--quiet']
     kwargs = {
         "stdin": sp.PIPE,
-        "shell": opts.use_shell
+        "shell": opts['use_shell']
     }
     if sys.version_info >= (3, 2, 0):
         kwargs["universal_newlines"] = False
     pipe = sp.Popen(cmd, **kwargs)
-    start_commit(pipe, git, opts.branch, opts.mesg)
-    for path, dnames, fnames in os.walk(srcdir, followlinks=opts.followlinks):
+    start_commit(pipe, git, opts['branch'], opts['mesg'])
+    for path, dnames, fnames in os.walk(srcdir, followlinks=opts['followlinks']):
         for fn in fnames:
             fpath = os.path.join(path, fn)
             fpath = normalize_path(fpath)
             gpath = gitpath(os.path.relpath(fpath, start=srcdir))
             add_file(pipe, fpath, gpath)
-    if opts.nojekyll:
+    if opts['nojekyll']:
         add_nojekyll(pipe)
-    if opts.cname is not None:
-        add_cname(pipe, opts.cname)
+    if opts['cname'] is not None:
+        add_cname(pipe, opts['cname'])
     write(pipe, enc('\n'))
     pipe.stdin.close()
     if pipe.wait() != 0:
@@ -216,6 +222,39 @@ def options():
     ]
 
 
+def ghp_import(srcdir, **kwargs):
+    if not os.path.isdir(srcdir):
+        raise GhpError("Not a directory: %s" % srcdir)
+
+    opts = {
+        'remote': 'origin',
+        'branch': 'gh-pages',
+        'mesg': 'Update documentation',
+        'push': False,
+        'force': False,
+        'use_shell': False,
+        'followlinks': False,
+        'cname': None,
+        'nojekyll': False
+    }
+
+    opts.update(kwargs)
+
+    git = Git(use_shell=opts['use_shell'])
+    git.check_repo()
+
+    if not git.try_rebase(opts['remote'], opts['branch']):
+        raise GhpError("Failed to rebase %s branch." % opts['branch'])
+
+    run_import(git, srcdir, **opts)
+
+    if push:
+        if force:
+            git.check_call('push', opts['remote'], opts['branch'], '--force')
+        else:
+            git.check_call('push', opts['remote'], opts['branch'])
+
+
 def main():
     parser = op.OptionParser(usage=__usage__, option_list=options())
     opts, args = parser.parse_args()
@@ -226,23 +265,10 @@ def main():
     if len(args) > 1:
         parser.error("Unknown arguments specified: %s" % ', '.join(args[1:]))
 
-    if not os.path.isdir(args[0]):
-        parser.error("Not a directory: %s" % args[0])
-
-    git = Git(use_shell=opts.use_shell)
-    git.check_repo(parser)
-
-    if not git.try_rebase(opts.remote, opts.branch):
-        parser.error("Failed to rebase %s branch." % opts.branch)
-
-    run_import(git, args[0], opts)
-
-    if opts.push:
-        if opts.force:
-            git.check_call('push', opts.remote, opts.branch, '--force')
-        else:
-            git.check_call('push', opts.remote, opts.branch)
-
+    try:
+        ghp_import(args[0], **opts.__dict__)
+    except GhpError as e:
+        parser.error(e.message)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Third party Python scripts can now call ghp-import directly. See
included documentation for details.

As an aside, this is made possible because of commit ef30cbf, which
now installs the module as a lib rather than a script and puts in
on the PYTHONPATH and makes it importable.