### PR TITLE
Set long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     version = "0.5.5",
     description = "Copy your docs directly to the gh-pages branch.",
     long_description = LONG_DESC,
+    long_description_content_type = 'text/markdown',
     author = "Paul Joseph Davis",
     author_email = "paul.joseph.davis@gmail.com",
     license = "Tumbolia Public License",


### PR DESCRIPTION
Because your project's long description is in Markdown, the `long_description_content_type` needs to be set to `text/markdown` in order for it to render on PyPI (cf. [how it fails to render now](https://pypi.org/project/ghp-import/0.5.5/)).  You will also need to use setuptools 38.3.0 or higher when building your project in order for this setting to be honored.