### PR TITLE
Add --squash-history option

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.9']
+        python-version: ['3.7', '3.12']
         os: [ubuntu, windows, macos]
         opts: ['--shell', '']
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Options:
                         out. [none]
   -f, --force           Force the push to the repository.
   -o, --no-history      Force new commit without parent history.
+  -a, --squash-history  Force squash commits, remove history but keep data.
   -r REMOTE, --remote=REMOTE
                         The name of the remote to push to. [origin]
   -b BRANCH, --branch=BRANCH
@@ -89,6 +90,11 @@ a different remote using the `-r` flag.
 The `-o` option will discard any previous history and ensure that only a
 single commit is always pushed to the `gh-pages` branch. This is useful to
 avoid bloating the repository size and is **highly recommended**.
+
+The `-a` option will discard some previous commits, keeping data. Only commits
+matching current commit message are discarded ("Update documentation" if `-m`
+option is not set). This is useful to avoid bloating the repository size but
+without discarding any data. Similar to `-o` but without data loss.
 
 You can specify a different branch with `-b`. This is useful for user and
 organization page, which are served from the `master` branch.

--- a/ghp_import.py
+++ b/ghp_import.py
@@ -197,12 +197,27 @@ def run_import(git, srcdir, **opts):
 
 
 def squash_history(git, branch, message=None):
-    filter_test = '[ "$(git rev-parse refs/heads/%s)" != "$GIT_COMMIT" ]' % branch
+    filter_test = (
+        '[ "$(git rev-parse refs/heads/%s)" != "$GIT_COMMIT" ] '
+        % branch
+    )
     if message:
-        filter_test += ' && [ $(git show -s --format=%%B "$GIT_COMMIT" | grep -c "%s") -gt 0 ]' % message
-    filter_script = 'if %s ; then skip_commit "$@"; else git commit-tree "$@"; fi' % filter_test
-    git.check_call('filter-branch', '--force', '--commit-filter', filter_script, 'refs/heads/%s' % branch,
-                   env={ **os.environ , 'FILTER_BRANCH_SQUELCH_WARNING':'1' })
+        filter_test += (
+            '&& [ $(git show -s --format=%%B "$GIT_COMMIT" '
+            '| grep -c "%s") -gt 0 ]'
+            % message
+        )
+    filter_script = (
+        'if %s ; then skip_commit "$@"; else git commit-tree "$@"; fi'
+        % filter_test
+    )
+    git.check_call(
+        'filter-branch',
+        '--force',
+        '--commit-filter', filter_script,
+        'refs/heads/%s' % branch,
+        env={**os.environ, 'FILTER_BRANCH_SQUELCH_WARNING': '1'}
+    )
 
 
 def options():

--- a/ghp_import.py
+++ b/ghp_import.py
@@ -201,8 +201,8 @@ def squash_history(git, branch, message=None):
     if message:
         filter_test += ' && [ $(git show -s --format=%%B "$GIT_COMMIT" | grep -c "%s") -gt 0 ]' % message
     filter_script = 'if %s ; then skip_commit "$@"; else git commit-tree "$@"; fi' % filter_test
-    # FILTER_BRANCH_SQUELCH_WARNING=1 ???
-    git.check_call('filter-branch', '--force', '--commit-filter', filter_script, 'refs/heads/%s' % branch)
+    git.check_call('filter-branch', '--force', '--commit-filter', filter_script, 'refs/heads/%s' % branch,
+                   env={ **os.environ , 'FILTER_BRANCH_SQUELCH_WARNING':'1' })
 
 
 def options():

--- a/ghp_import.py
+++ b/ghp_import.py
@@ -196,6 +196,15 @@ def run_import(git, srcdir, **opts):
         sys.stdout.write(enc("Failed to process commit.\n"))
 
 
+def squash_history(git, branch, message=None):
+    filter_test = '[ "$(git rev-parse refs/heads/%s)" != "$GIT_COMMIT" ]' % branch
+    if message:
+        filter_test += ' && [ $(git show -s --format=%%B "$GIT_COMMIT" | grep -c "%s") -gt 0 ]' % message
+    filter_script = 'if %s ; then skip_commit "$@"; else git commit-tree "$@"; fi' % filter_test
+    # FILTER_BRANCH_SQUELCH_WARNING=1 ???
+    git.check_call('filter-branch', '--force', '--commit-filter', filter_script, 'refs/heads/%s' % branch)
+
+
 def options():
     return [
         (('-n', '--no-jekyll'), dict(
@@ -238,6 +247,12 @@ def options():
             action='store_true',
             help='Force new commit without parent history.',
         )),
+        (('-a', '--squash-history'), dict(
+            dest='squash_history',
+            default=False,
+            action='store_true',
+            help='Force squash commits, remove history but keep data.',
+        )),
         (('-r', '--remote'), dict(
             dest='remote',
             default='origin',
@@ -277,6 +292,9 @@ def ghp_import(srcdir, **kwargs):
         raise GhpError("Failed to rebase %s branch." % opts['branch'])
 
     run_import(git, srcdir, **opts)
+
+    if opts['squash_history']:
+        squash_history(git, opts['branch'], opts['mesg'])
 
     if opts['push']:
         if opts['force'] or opts['no_history']:


### PR DESCRIPTION
Issue: https://github.com/c-w/ghp-import/issues/126

This option is similar to --no-history (avoid bloating the repository size) but keep data. We squash all commits from gh-pages branch filtered on the current commit message.

This allow workflows like keeping commits and data for a released doc and always override nightlies documentations.